### PR TITLE
Three bugs fixed, maybe

### DIFF
--- a/src/Call/Internal/GLFW.hs
+++ b/src/Call/Internal/GLFW.hs
@@ -57,7 +57,7 @@ installTexture (Image w h v) = do
   let siz = GL.TextureSize2D (gsizei w) (gsizei h)
   V.unsafeWith v
     $ GL.texImage2D GL.Texture2D GL.NoProxy 0 GL.RGBA8 siz 0
-    . GL.PixelData GL.ABGR GL.UnsignedInt8888
+    . GL.PixelData GL.RGBA GL.UnsignedInt8888
   return (tex, fromIntegral w / 2, fromIntegral h / 2)
 
 releaseTexture :: Texture -> IO ()
@@ -86,7 +86,7 @@ beginGLFW mode bbox@(Box (V2 x0 y0) (V2 x1 y1)) = do
     _ -> return Nothing
 
   GLFW.windowHint $ GLFW.WindowHint'ContextVersionMajor 3
-  GLFW.windowHint $ GLFW.WindowHint'ContextVersionMinor 3
+  GLFW.windowHint $ GLFW.WindowHint'ContextVersionMinor 2
   GLFW.windowHint $ GLFW.WindowHint'OpenGLProfile GLFW.OpenGLProfile'Core
   GLFW.windowHint $ GLFW.WindowHint'OpenGLForwardCompat True
 

--- a/src/Call/System.hs
+++ b/src/Call/System.hs
@@ -408,8 +408,8 @@ drawScene fo (fmap round -> Box (V2 x0 y0) (V2 x1 y1)) proj _ (Scene s) = do
       withLoc "envAdd" $ \loc -> GL.glUniform1f loc 1
       (tex, _, _) <- fetchTexture fo bmp h
       GL.activeTexture $= GL.TextureUnit 1
-      GL.textureFilter GL.Texture2D $= ((GL.Linear', Nothing), GL.Linear')
       GL.textureBinding GL.Texture2D $= Just tex
+      GL.textureFilter GL.Texture2D $= ((GL.Linear', Nothing), GL.Linear')
       m c
       withLoc "useEnv" $ \loc -> GL.glUniform1i loc 0
       withLoc "envAdd" $ \loc -> GL.glUniform1f loc 0
@@ -420,8 +420,8 @@ drawScene fo (fmap round -> Box (V2 x0 y0) (V2 x1 y1)) proj _ (Scene s) = do
       (tex, _, _) <- fetchTexture fo bmp h
 
       GL.activeTexture $= GL.TextureUnit 1
-      GL.textureFilter GL.Texture2D $= ((GL.Linear', Nothing), GL.Linear')
       GL.textureBinding GL.Texture2D $= Just tex
+      GL.textureFilter GL.Texture2D $= ((GL.Linear', Nothing), GL.Linear')
       m c
       withLoc "useEnv" $ \loc -> GL.glUniform1i loc 0
       withLoc "envMul" $ \loc -> GL.glUniform1f loc 0


### PR DESCRIPTION
On OSX there are at least three problems:
- Window won't open at all because Opengl 3.3 is requested. Must be 3.2.
- Image data loading incorrectly, causing black rectangles instead of
  circles in the rhythm game tutorial. The JuicyPixels Image type clear
  says RGBA format but GL is told to load ABGR, fixed.
- Texture filtering is being set out of order, with the texture binding
  happening after the filtering setting. Swapped.
